### PR TITLE
Add UserScreen with Role Filtering

### DIFF
--- a/src/hooks/useUsers.ts
+++ b/src/hooks/useUsers.ts
@@ -1,0 +1,26 @@
+import {useQuery} from '@apollo/client';
+import {LIST_ZELLER_CUSTOMERS} from '../graphql/queries';
+import {ZellerCustomerConnection} from '../types/user';
+
+interface ListZellerCustomersData {
+  listZellerCustomers: ZellerCustomerConnection;
+}
+
+interface ListZellerCustomersVars {
+  filter: {role: {eq: string}};
+}
+
+export const useUsers = (role: string) => {
+  const {data, loading, error} = useQuery<
+    ListZellerCustomersData,
+    ListZellerCustomersVars
+  >(LIST_ZELLER_CUSTOMERS, {
+    variables: {filter: {role: {eq: role}}},
+  });
+
+  return {
+    users: data?.listZellerCustomers.items || [],
+    loading,
+    error,
+  };
+};

--- a/src/screens/UserScreen/UserScreen.test.tsx
+++ b/src/screens/UserScreen/UserScreen.test.tsx
@@ -1,0 +1,52 @@
+// src/screens/UserScreen/UserScreen.test.tsx
+import React from 'react';
+import {render, fireEvent} from '@testing-library/react-native';
+import {MockedProvider} from '@apollo/client/testing';
+import UserScreen from './UserScreen';
+import {LIST_ZELLER_CUSTOMERS} from '../../graphql/queries';
+
+const mocks = [
+  {
+    request: {
+      query: LIST_ZELLER_CUSTOMERS,
+      variables: {filter: {role: {eq: 'Admin'}}},
+    },
+    result: {
+      data: {
+        listZellerCustomers: {
+          items: [
+            {
+              id: '1',
+              name: 'John Smith',
+              email: 'john@example.com',
+              role: 'Admin',
+            },
+          ],
+          nextToken: null,
+        },
+      },
+    },
+  },
+];
+
+describe('UserScreen', () => {
+  it('renders users after fetching', async () => {
+    const {findByText} = render(
+      <MockedProvider mocks={mocks} addTypename={false}>
+        <UserScreen />
+      </MockedProvider>,
+    );
+    const userName = await findByText('John Smith');
+    expect(userName).toBeTruthy();
+  });
+
+  it('switches role filter', async () => {
+    const {getByText} = render(
+      <MockedProvider mocks={mocks} addTypename={false}>
+        <UserScreen />
+      </MockedProvider>,
+    );
+    fireEvent.press(getByText('Manager'));
+    expect(getByText('Manager Users')).toBeTruthy();
+  });
+});

--- a/src/screens/UserScreen/UserScreen.tsx
+++ b/src/screens/UserScreen/UserScreen.tsx
@@ -1,0 +1,55 @@
+import React, {useState} from 'react';
+import {View, Text, ActivityIndicator, StyleSheet} from 'react-native';
+import RadioButton from '../../components/RadioButton/RadioButton';
+import UserList from '../../components/UserList/UserList';
+import {useUsers} from '../../hooks/useUsers';
+
+const UserScreen: React.FC = () => {
+  const [selectedRole, setSelectedRole] = useState<string>('Admin');
+  const {users, loading, error} = useUsers(selectedRole);
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.section}>
+        <Text style={styles.header}>User Types</Text>
+        <RadioButton
+          label="Admin"
+          selected={selectedRole === 'Admin'}
+          onPress={() => setSelectedRole('Admin')}
+        />
+        <RadioButton
+          label="Manager"
+          selected={selectedRole === 'Manager'}
+          onPress={() => setSelectedRole('Manager')}
+        />
+      </View>
+      <View style={styles.section}>
+        <Text style={styles.header}>{selectedRole} Users</Text>
+        {loading ? (
+          <ActivityIndicator size="large" color="#0057FF" testID="loading" />
+        ) : error ? (
+          <Text style={styles.errorText}>Error: {error.message}</Text>
+        ) : users.length > 0 ? (
+          <UserList users={users} />
+        ) : (
+          <Text style={styles.noUsersText}>No users found</Text>
+        )}
+      </View>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {flex: 1, padding: 10, backgroundColor: '#FFFFFF'},
+  section: {marginBottom: 20},
+  header: {
+    fontSize: 18,
+    fontWeight: 'bold',
+    color: '#000000',
+    marginBottom: 10,
+  },
+  errorText: {color: 'red', textAlign: 'center', marginTop: 20},
+  noUsersText: {textAlign: 'center', marginTop: 20, color: '#757575'},
+});
+
+export default UserScreen;


### PR DESCRIPTION
This PR adds the UserScreen, which integrates the RadioButton and UserList components to display and filter users by role using GraphQL.

### Changes
- Added `useUsers` hook in `src/hooks/useUsers.ts` for fetching users.
- Added `UserScreen` in `src/screens/UserScreen` with role filtering.
- Included unit tests for the screen.